### PR TITLE
Remove Basic Auth references

### DIFF
--- a/public/Get-ISCAccessProfile.ps1
+++ b/public/Get-ISCAccessProfile.ps1
@@ -27,7 +27,8 @@ Function Get-ISCAccessProfile {
     PS> Get-ISCAccessProfile -ID "2cXXXXXXXXXXXXXXXXXXXXXXXXXXXX50"
 
 .LINK
-    
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(

--- a/public/Get-ISCAccount.ps1
+++ b/public/Get-ISCAccount.ps1
@@ -16,7 +16,8 @@ Function Get-ISCAccount {
     PS> Get-ISCAccount -ID 2cXXXXXXXXXXXXXXXXXXXXXXXXXXXX50
 
 .LINK
-    
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(

--- a/public/Get-ISCConnection.ps1
+++ b/public/Get-ISCConnection.ps1
@@ -19,11 +19,12 @@ Function Get-ISCConnection {
     TokenExpiration : 01/01/2019 3:42:30 PM
     Environment     : foo
     Token           : [token]
-    v2URL           : https://instance.api.identitynow.com/v2
+    Domain          : Default
     v3URL           : https://instance.api.identitynow.com
 
 .LINK
-    
+    https://github.com/sup3rmark/iscUtils
+
 #>
 
     [CmdletBinding()]
@@ -37,8 +38,8 @@ Function Get-ISCConnection {
     $connectionObject | Add-Member -Type NoteProperty -Name 'Timestamp' -Value $script:iscConnectionTimestamp
     $connectionObject | Add-Member -Type NoteProperty -Name 'TokenExpiration' -Value $script:iscConnectionExpiration
     $connectionObject | Add-Member -Type NoteProperty -Name 'Tenant' -Value $script:iscTenant
+    $connectionObject | Add-Member -Type NoteProperty -Name 'Domain' -Value $script:iscDomain
     $connectionObject | Add-Member -Type NoteProperty -Name 'Token' -Value $script:iscOauthToken.access_token
-    $connectionObject | Add-Member -Type NoteProperty -Name 'v2URL' -Value $script:iscV2APIurl
     $connectionObject | Add-Member -Type NoteProperty -Name 'v3URL' -Value $script:iscV3APIurl
     if ($IncludeSources.IsPresent) {
         $connectionObject | Add-Member -Type NoteProperty -Name 'SourceList' -Value $script:iscSources

--- a/public/Get-ISCConnectorRule.ps1
+++ b/public/Get-ISCConnectorRule.ps1
@@ -20,7 +20,8 @@ Function Get-ISCConnectorRule {
     PS> Get-ISCConnectorRule -All
 
 .LINK
-    
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(

--- a/public/Get-ISCEntitlement.ps1
+++ b/public/Get-ISCEntitlement.ps1
@@ -16,7 +16,8 @@ Function Get-ISCEntitlement {
     PS> Get-ISCEntitlement -ID 2cXXXXXXXXXXXXXXXXXXXXXXXXXXXX50
 
 .LINK
-    
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(

--- a/public/Get-ISCIdentity.ps1
+++ b/public/Get-ISCIdentity.ps1
@@ -29,7 +29,8 @@ Function Get-ISCIdentity {
     PS> Get-ISCIdentity -List -Active
 
 .LINK
-    
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(

--- a/public/Get-ISCPendingTaskList.ps1
+++ b/public/Get-ISCPendingTaskList.ps1
@@ -16,7 +16,8 @@ Function Get-ISCPendingTaskList {
     PS> Get-ISCPendingTaskList
 
 .LINK
-    
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(

--- a/public/Get-ISCTransform.ps1
+++ b/public/Get-ISCTransform.ps1
@@ -20,7 +20,8 @@ Function Get-ISCTransform {
     PS> Get-ISCTransform -All
 
 .LINK
-    https://github.csnzoo.com/shared/pwsh-iscUtils
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(

--- a/public/Get-ISCWorkflow.ps1
+++ b/public/Get-ISCWorkflow.ps1
@@ -20,6 +20,7 @@ Function Get-ISCWorkflow {
     PS> Get-ISCWorkflow -All
 
 .LINK
+    https://github.com/sup3rmark/iscUtils
 
 #>
     [CmdletBinding()]

--- a/public/Get-ISCWorkflowExecution.ps1
+++ b/public/Get-ISCWorkflowExecution.ps1
@@ -20,6 +20,7 @@ Function Get-ISCWorkflowExecution {
     PS> Get-ISCWorkflow -All
 
 .LINK
+    https://github.com/sup3rmark/iscUtils
 
 #>
     [CmdletBinding()]

--- a/public/Get-ISCWorkflowExecutionList.ps1
+++ b/public/Get-ISCWorkflowExecutionList.ps1
@@ -16,6 +16,8 @@ Function Get-ISCWorkflowExecutionList {
     PS> Get-ISCWorkflowExecutionList -ID 5xxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxd
 
 .LINK
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(

--- a/public/Invoke-ISCQuery.ps1
+++ b/public/Invoke-ISCQuery.ps1
@@ -16,7 +16,8 @@ Function Invoke-ISCQuery {
     PS> Invoke-ISCQuery
 
 .LINK
-    
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(

--- a/public/Set-ISCAccessProfile.ps1
+++ b/public/Set-ISCAccessProfile.ps1
@@ -31,7 +31,8 @@ DYNAMIC PARAMETERS
     PS> Get-ISCAccessProfile -Name testProfile | Set-ISCAccessProfile -OwnerEmID 2798
 
 .LINK
-    https://github.csnzoo.com/shared/pwsh-iscUtils
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param(

--- a/public/Set-ISCEntitlement.ps1
+++ b/public/Set-ISCEntitlement.ps1
@@ -37,6 +37,8 @@ DYNAMIC PARAMETERS
     PS> Get-ISCEntitlement -Name testEntitlement | Set-ISCEntitlement -Privileged $false
 
 .LINK
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param(
@@ -92,7 +94,7 @@ DYNAMIC PARAMETERS
     process {
         $spUserParam = @{}
         $spUserParam = $(if ($OwnerEmployeeNumber) {
-                @{EmID = "$OwnerEmployeeNumber" }
+                @{EmployeeNumber = "$OwnerEmployeeNumber" }
             }
             elseif ($OwnerSamAccountName) {
                 @{SamAccountName = "$OwnerSamAccountName" }
@@ -114,7 +116,7 @@ DYNAMIC PARAMETERS
         if ($DisplayName -and ($DisplayName -ne $existingEntitlement.name)) { $changes += @{ op = 'replace'; path = '/name'; value = "$DisplayName" } }
         if ($Description -and ($Description -ne $existingEntitlement.description)) { $changes += @{ op = 'replace'; path = '/description'; value = "$Description" } }
         if ($OwnerID -and ($OwnerID -ne $existingEntitlement.owner.id)) { $changes += @{ op = 'replace'; path = '/owner'; value = @{ id = $OwnerID; type = 'IDENTITY' } } }
-        if ($Privileged -and ($Privileged -ne $existingEntitlement.privileged)) { $changes += @{ op = 'replace'; path = '/enabled'; value = $Privileged } }
+        if ($Privileged -and ($Privileged -ne $existingEntitlement.privileged)) { $changes += @{ op = 'replace'; path = '/privileged'; value = $Privileged } }
         if ($Requestable -and ($Requestable -ne $existingEntitlement.requestable)) { $changes += @{ op = 'replace'; path = '/requestable'; value = $Requestable } }
 
         if ($RemoveOwner) { $changes += @{ op = 'remove'; path = '/owner' } }

--- a/public/Set-ISCTaskCompleted.ps1
+++ b/public/Set-ISCTaskCompleted.ps1
@@ -17,6 +17,8 @@ Function Set-ISCTaskCompleted {
     PS> Set-ISCTaskCompleted -ID 2xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx4
 
 .LINK
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding(DefaultParameterSetName = 'Default')]
     param(

--- a/public/Test-ISCConnection.ps1
+++ b/public/Test-ISCConnection.ps1
@@ -18,7 +18,8 @@ Function Test-ISCConnection {
     PS> Test-ISCConnection
 
 .LINK
-    https://github.csnzoo.com/shared/pwsh-iscUtils
+    https://github.com/sup3rmark/iscUtils
+
 #>
     [CmdletBinding()]
     param(
@@ -31,14 +32,14 @@ Function Test-ISCConnection {
     
     # If the connection is older than the default expiration time, and $ReconnectAutomatically isn't flagged, abort
     if (-NOT $spConnection.Timestamp) {
-        throw 'ERROR: Connection to Identity Security Cloud has not been established. You must first connect manually using Connect-ISCAPI.'
+        throw 'ERROR: Connection to Identity Security Cloud has not been established. You must first connect manually using Connect-ISC.'
     }
 
     if ($spConnection.TokenExpiration -lt $(Get-Date) -AND -NOT $ReconnectAutomatically) {
-        throw 'ERROR: Connection is likely expired. Either reconnect manually using Connect-ISCAPI or use -ReconnectAutomatically flag.'
+        throw 'ERROR: Connection is likely expired. Either reconnect manually using Connect-ISC or use -ReconnectAutomatically flag.'
     }
     elseif ($spConnection.TokenExpiration -lt $(Get-Date) -AND $ReconnectAutomatically) {
-        Connect-ISCAPI -Tenant $spConnection.Tenant
+        Connect-ISC -Tenant $spConnection.Tenant -Domain $spConnection.Domain
         Write-Verbose 'INFO: Connection is likely expired. Reconnecting automatically.'
         Return $(Get-ISCConnection)
     }


### PR DESCRIPTION
Basic Auth is no longer relevant, so I'm removing the lines for that in the `Connect-ISC` cmdlet.

Additional minor changes:
- Change auth to use a Form submission rather than including clientID/clientSecret in the URL so the credentials aren't output when `-Verbose` is specified.
- Update command-based help for all functions
- Set `-Tenant` param to Required for `Connect-ISC`.
- Remove `v2URL` from connection information, and add `Domain`.
- Bugfixes for Set-ISCEntitlement to correct param names used.