### PR TITLE
Remove SamAccountName param from Get-ISCIdentity

### DIFF
--- a/public/Get-ISCIdentity.ps1
+++ b/public/Get-ISCIdentity.ps1
@@ -53,14 +53,6 @@ Function Get-ISCIdentity {
         [ValidateNotNullOrEmpty()]
         [String] $ID,
 
-        # Enter the SamAccountName of a specific identity to retrieve.
-        [Parameter (
-            Mandatory = $true,
-            ParameterSetName = 'SamAccountName'
-        )]
-        [ValidateNotNullOrEmpty()]
-        [String] $SamAccountName,
-
         # Enter the EmployeeNumber of a specific identity to retrieve.
         [Parameter (
             Mandatory = $true,


### PR DESCRIPTION
SamAccountName is not a default Identity Attribute and may cause confusion. This functionality can still be achieved for environments which do contain a samaccountname identity attribute by using the `-CustomQuery` parameter.