### PR TITLE
Add New-ISCTenant function

### DIFF
--- a/public/New-ISCTenant.ps1
+++ b/public/New-ISCTenant.ps1
@@ -1,0 +1,74 @@
+Function New-ISCTenant {
+    <#
+.SYNOPSIS
+    Create a stored credential for a new ISC tenant.
+
+.DESCRIPTION
+    Use this function to easily create and store a credential object for a specific ISC tenant.
+
+.INPUTS
+    None
+
+.OUTPUTS
+    None
+
+.EXAMPLE
+    PS> New-ISCTenant -Tenant foo -ClientID $clientId -ClientSecret $clientSecret
+
+.EXAMPLE
+    PS> New-ISCTenant -Tenant foo -ClientID bar -ClientSecret ('bash' | ConvertTo-SecureString -AsPlainText -Force)
+
+.EXAMPLE
+    PS> New-ISCTenant -Tenant foo -Credential $credentialObject
+
+.LINK
+    https://github.com/sup3rmark/iscUtils
+
+#>
+
+    [CmdletBinding()]
+    param(
+        # Define the tenant to which you want to add a credential for.
+        [Alias('Environment')]
+        [Parameter (Mandatory = $true)]
+        [ValidateNotNullOrWhiteSpace()]
+        [String] $Tenant,
+
+        # Specify the Client ID you'd like to store.
+        [Parameter (
+            Mandatory = $true,
+            ParameterSetName = 'ClientCredentials'
+        )]
+        [ValidateNotNullOrWhiteSpace()]
+        [String] $ClientID,
+
+        # Specify the Client Secret you'd like to store.
+        [Parameter (
+            Mandatory = $true,
+            ParameterSetName = 'ClientCredentials'
+        )]
+        [ValidateNotNullOrWhiteSpace()]
+        [SecureString] $ClientSecret,
+
+        # Specify the Credential Object you'd like to store.
+        [Parameter (
+            Mandatory = $true,
+            ParameterSetName = 'CredentialObject'
+        )]
+        [ValidateNotNullOrWhiteSpace()]
+        [System.Management.Automation.PSCredential]
+        [System.Management.Automation.Credential()] $Credential
+    )
+
+    if ($PsCmdlet.ParameterSetName -eq 'ClientCredentials') {
+        $Credential = [PSCredential]::New($ClientID, $ClientSecret)
+    }
+
+    if ($Credential) {
+        Set-Secret -Name "ISC - $Tenant API" -Secret $Credential
+        Write-Host "Configuration saved for $Tenant tenant."
+    }
+    else {
+        throw 'No credential provided.'
+    }
+}


### PR DESCRIPTION
This function allows users to create a properly-formatted Secret object more easily by just passing in the tenant name and either a clientID/clientSecret pair or a PowerShell Credential object.