### PR TITLE
Store Domain in Secret metadata

### DIFF
--- a/public/Get-ISCAccessProfile.ps1
+++ b/public/Get-ISCAccessProfile.ps1
@@ -83,7 +83,7 @@ Function Get-ISCAccessProfile {
         $null
     }
     
-    $uri = "$script:iscV3APIurl/v3/access-profiles?$filter"
+    $uri = "$script:iscAPIurl/v3/access-profiles?$filter"
     $response = Invoke-RestMethod -Uri $uri @script:bearerAuthArgs
     $accessProfileData = $response
     Write-Verbose "Retrieved $($accessProfileData.count) items."

--- a/public/Get-ISCAccount.ps1
+++ b/public/Get-ISCAccount.ps1
@@ -103,7 +103,7 @@ Function Get-ISCAccount {
             $filters += "sourceId eq `"$(($script:ISCSources | Where-Object {$_.Name -eq $Source}).id)`""
         }
 
-        $baseURL = "$script:iscV3APIurl/v3/accounts?count=true"
+        $baseURL = "$script:iscAPIurl/v3/accounts?count=true"
         if ($filters) {
             $baseURL += "&filters=$($filters -join ' and ')"
         }

--- a/public/Get-ISCConnection.ps1
+++ b/public/Get-ISCConnection.ps1
@@ -40,7 +40,7 @@ Function Get-ISCConnection {
     $connectionObject | Add-Member -Type NoteProperty -Name 'Tenant' -Value $script:iscTenant
     $connectionObject | Add-Member -Type NoteProperty -Name 'Domain' -Value $script:iscDomain
     $connectionObject | Add-Member -Type NoteProperty -Name 'Token' -Value $script:iscOauthToken.access_token
-    $connectionObject | Add-Member -Type NoteProperty -Name 'v3URL' -Value $script:iscV3APIurl
+    $connectionObject | Add-Member -Type NoteProperty -Name 'API URL' -Value $script:iscAPIurl
     if ($IncludeSources.IsPresent) {
         $connectionObject | Add-Member -Type NoteProperty -Name 'SourceList' -Value $script:iscSources
     }

--- a/public/Get-ISCConnectorRule.ps1
+++ b/public/Get-ISCConnectorRule.ps1
@@ -57,7 +57,7 @@ Function Get-ISCConnectorRule {
         throw $_.Exception
     }
 
-    $url = "$script:iscV3APIurl/beta/connector-rules"
+    $url = "$script:iscAPIurl/beta/connector-rules"
     if ($Id) {
         $url += "/$Id"
     }

--- a/public/Get-ISCEntitlement.ps1
+++ b/public/Get-ISCEntitlement.ps1
@@ -149,7 +149,7 @@ Function Get-ISCEntitlement {
             $filters += "source.id eq `"$(($script:ISCSources | Where-Object {$_.Name -eq $Source}).id)`""
         }
 
-        $baseURL = "$script:iscV3APIurl/beta/entitlements?count=true"
+        $baseURL = "$script:iscAPIurl/beta/entitlements?count=true"
         if ($filters) {
             $query += "&filters=$($filters -join ' and ')"
         }

--- a/public/Get-ISCIdentity.ps1
+++ b/public/Get-ISCIdentity.ps1
@@ -132,7 +132,7 @@ Function Get-ISCIdentity {
     }
     Write-Verbose "Query:`n$($query | ConvertTo-Json)"
 
-    $uri = "$script:iscV3APIurl/v3/search"
+    $uri = "$script:iscAPIurl/v3/search"
     Write-Verbose "Query URL: $uri"
 
     $response = Invoke-RestMethod -Uri "$uri`?count=true" -Method Post -ResponseHeadersVariable responseHeaders -Body ($query | ConvertTo-Json) @script:bearerAuthArgs

--- a/public/Get-ISCPendingTaskList.ps1
+++ b/public/Get-ISCPendingTaskList.ps1
@@ -46,7 +46,7 @@ Function Get-ISCPendingTaskList {
             throw $_.Exception
         }
 
-        $baseURL = "$script:iscV3APIurl/beta/task-status/pending-tasks?limit=$Limit"
+        $baseURL = "$script:iscAPIurl/beta/task-status/pending-tasks?limit=$Limit"
 
         $tasksData = @()
         do {

--- a/public/Get-ISCSource.ps1
+++ b/public/Get-ISCSource.ps1
@@ -72,7 +72,7 @@ Function Get-ISCSource {
             throw $_.Exception
         }
 
-        $baseURL = "$script:iscV3APIurl/v3/sources"
+        $baseURL = "$script:iscAPIurl/v3/sources"
 
         $sourcesData = @()
         do {

--- a/public/Get-ISCSourceSchema.ps1
+++ b/public/Get-ISCSourceSchema.ps1
@@ -86,7 +86,7 @@ Function Get-ISCSourceSchema {
             throw $_.Exception
         }
 
-        $baseURL = "$script:iscV3APIurl/v3/sources/$(($script:ISCSources | Where-Object {$_.Name -eq $Source}).id)/schemas"
+        $baseURL = "$script:iscAPIurl/v3/sources/$(($script:ISCSources | Where-Object {$_.Name -eq $Source}).id)/schemas"
 
         $schamasData = @()
         do {

--- a/public/Get-ISCTaskList.ps1
+++ b/public/Get-ISCTaskList.ps1
@@ -46,7 +46,7 @@ Function Get-ISCTaskList {
             throw $_.Exception
         }
 
-        $baseURL = "$script:iscV3APIurl/beta/task-status?limit=$Limit"
+        $baseURL = "$script:iscAPIurl/beta/task-status?limit=$Limit"
 
         $tasksData = @()
         do {

--- a/public/Get-ISCTransform.ps1
+++ b/public/Get-ISCTransform.ps1
@@ -62,7 +62,7 @@ Function Get-ISCTransform {
         throw $_.Exception
     }
 
-    $baseURL = "$script:iscV3APIurl/v3/transforms?count=true"
+    $baseURL = "$script:iscAPIurl/v3/transforms?count=true"
     if ($Name) {
         $baseURL += "&name=$Name"
     }

--- a/public/Get-ISCWorkflow.ps1
+++ b/public/Get-ISCWorkflow.ps1
@@ -81,7 +81,7 @@ Function Get-ISCWorkflow {
         throw $_.Exception
     }
 
-    $url = "$script:iscV3APIurl/v3/workflows"
+    $url = "$script:iscAPIurl/v3/workflows"
     if ($ID) {
         $url += "/$ID"
     }

--- a/public/Get-ISCWorkflowExecution.ps1
+++ b/public/Get-ISCWorkflowExecution.ps1
@@ -51,7 +51,7 @@ Function Get-ISCWorkflowExecution {
         throw $_.Exception
     }
 
-    $url = "$script:iscV3APIurl/v3/workflow-executions/$ID/history"
+    $url = "$script:iscAPIurl/v3/workflow-executions/$ID/history"
     
     Write-Verbose "Calling $url"
     try {

--- a/public/Get-ISCWorkflowExecutionList.ps1
+++ b/public/Get-ISCWorkflowExecutionList.ps1
@@ -86,7 +86,7 @@ Function Get-ISCWorkflowExecutionList {
     if ($filters) {
         $params += "filters=$($filters -join ' and ')"
     }
-    $baseURL = "$script:iscV3APIurl/v3/workflows/$ID/executions?$($params -join '&')"
+    $baseURL = "$script:iscAPIurl/v3/workflows/$ID/executions?$($params -join '&')"
 
     $executionsData = @()
     do {

--- a/public/Invoke-ISCQuery.ps1
+++ b/public/Invoke-ISCQuery.ps1
@@ -56,7 +56,7 @@ Function Invoke-ISCQuery {
             includeNested = $false
             sort          = @('id')
         }
-        $baseURL = "$script:iscV3APIurl/v3/search"
+        $baseURL = "$script:iscAPIurl/v3/search"
         Write-Verbose "Calling $baseURL"
         Write-Verbose ($body | ConvertTo-Json)
 

--- a/public/New-ISCTenant.ps1
+++ b/public/New-ISCTenant.ps1
@@ -57,7 +57,12 @@ Function New-ISCTenant {
         )]
         [ValidateNotNullOrWhiteSpace()]
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()] $Credential
+        [System.Management.Automation.Credential()] $Credential,
+
+        # Optionally specify which domain the tenant is in.
+        [Parameter (Mandatory = $false)]
+        [ValidateSet('Default', 'Demo', 'FedRamp')]
+        [String] $Domain
     )
 
     if ($PsCmdlet.ParameterSetName -eq 'ClientCredentials') {
@@ -65,7 +70,15 @@ Function New-ISCTenant {
     }
 
     if ($Credential) {
-        Set-Secret -Name "ISC - $Tenant API" -Secret $Credential
+        $splat = @{
+            Name   = "ISC - $Tenant API"
+            Secret = $Credential 
+        }
+        if ($Domain) {
+            $splat += @{ Metadata = @{ Domain = $Domain } }
+            Write-Verbose "$Domain Domain added to Secret Metadata."
+        }
+        Set-Secret @splat
         Write-Host "Configuration saved for $Tenant tenant."
     }
     else {

--- a/public/Set-ISCAccessProfile.ps1
+++ b/public/Set-ISCAccessProfile.ps1
@@ -138,7 +138,7 @@ Function Set-ISCAccessProfile {
                 $body = @( $changes )
                 Write-Verbose 'JSON:'
                 Write-Verbose (ConvertTo-Json $body)
-                $setAccessProfileURL = "$script:iscV3APIurl/v3/access-profiles/$ID"
+                $setAccessProfileURL = "$script:iscAPIurl/v3/access-profiles/$ID"
                 Write-Verbose "URL: $setAccessProfileURL"
 
                 $setAccessProfileArgs = @{

--- a/public/Set-ISCEntitlement.ps1
+++ b/public/Set-ISCEntitlement.ps1
@@ -121,7 +121,7 @@ Function Set-ISCEntitlement {
                 $body = @( $changes )
                 Write-Verbose 'JSON:'
                 Write-Verbose (ConvertTo-Json $body)
-                $setEntitlementURL = "$script:iscV3APIurl/beta/entitlements/$ID"
+                $setEntitlementURL = "$script:iscAPIurl/beta/entitlements/$ID"
                 Write-Verbose "URL: $setEntitlementURL"
 
                 $setEntitlementArgs = @{

--- a/public/Set-ISCTaskCompleted.ps1
+++ b/public/Set-ISCTaskCompleted.ps1
@@ -57,7 +57,7 @@ Function Set-ISCTaskCompleted {
             $body = @( $changes )
             Write-Verbose 'JSON:'
             Write-Verbose (ConvertTo-Json $body)
-            $url = "$script:iscV3APIurl/beta/task-status/$ID"
+            $url = "$script:iscAPIurl/beta/task-status/$ID"
             Write-Verbose "URL: $url"
 
             $taskArgs = @{


### PR DESCRIPTION
- Add option to store tenant domain in Secret metadata so it doesn't need to be provided on every connection attempt
- Remove "v3" from API URL variable name